### PR TITLE
the runAsUser change was missed in cainjector

### DIFF
--- a/stable/cert-manager-webhook/charts/cert-manager-cainjector/values.yaml
+++ b/stable/cert-manager-webhook/charts/cert-manager-cainjector/values.yaml
@@ -49,12 +49,12 @@ image:
 securityContext:
   pod:
     runAsNonRoot: true
-    runAsUser: 10000
+    runAsUser: 1001010000
   container:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: false
     runAsNonRoot: true
-    runAsUser: 10000
+    runAsUser: 1001010000
     privileged: false
 
 podDnsPolicy: "ClusterFirstWithHostNet"


### PR DESCRIPTION
The runAsUser change was missed in the cert-manager-webhook cainjector subchart.