### PR TITLE
provide needed defaults for configmap watcher

### DIFF
--- a/stable/cert-manager-webhook/values.yaml
+++ b/stable/cert-manager-webhook/values.yaml
@@ -67,9 +67,9 @@ serviceAccount:
 affinity: {}
 
 watcher:
-  optIn: false
+  optIn: true
   configmap:
-    name:
-    namespace: 
+    name: extension-apiserver-authentication
+    namespace: kube-system
 
 pkiNamespace: "kube-system"


### PR DESCRIPTION
Add config to help fix issue https://github.com/open-cluster-management/backlog/issues/927.  The install team will need to remove their customizations for the values being provided so that the watcher config has this:

```
  watcher:
    optIn: true
    configmap:
      name: "extension-apiserver-authentication"
      namespace: "kube-system"
```