### PR TITLE
init the configmaps so helm can clean them up

### DIFF
--- a/stable/cert-manager-webhook/charts/cert-manager-cainjector/templates/configmap.yaml
+++ b/stable/cert-manager-webhook/charts/cert-manager-cainjector/templates/configmap.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cert-manager-cainjector-leader-election
+  {{- if .Values.global.leaderElection.namespace }}
+  namespace: {{ .Values.global.leaderElection.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
+  labels:
+    app: {{ template "cainjector.name" . }}
+    chart: {{ template "cainjector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cert-manager-cainjector-leader-election-core
+  {{- if .Values.global.leaderElection.namespace }}
+  namespace: {{ .Values.global.leaderElection.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
+  labels:
+    app: {{ template "cainjector.name" . }}
+    chart: {{ template "cainjector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}


### PR DESCRIPTION
Initialize the configmaps used by the webhook for leader election.
This is done so helm can clean them up.
https://github.com/open-cluster-management/backlog/issues/787