### PR TITLE
disable the webhook for the ocm release namespace

### DIFF
--- a/stable/cert-manager-webhook/templates/validating-webhook.yaml
+++ b/stable/cert-manager-webhook/templates/validating-webhook.yaml
@@ -7,18 +7,10 @@ metadata:
     chart: {{ include "webhook.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  annotations:
-{{- if .Values.injectAPIServerCA }}
-    certmanager.k8s.io/inject-apiserver-ca: "true"
-{{- end }}
 webhooks:
   - name: webhook.certmanager.k8s.io
     namespaceSelector:
       matchExpressions:
-      - key: "certmanager.k8s.io/disable-validation"
-        operator: "NotIn"
-        values:
-        - "true"
       - key: "name"
         operator: "NotIn"
         values:


### PR DESCRIPTION
This will disable the webhook for the namespace where cert-manager is installed.
This means the webhook will be disabled for "itself".  The was desired in previous releases but since we had not seen issues we did not have this disabled.  I think this is the first issue I'm aware of with the chicken-and-egg of webhook protecting certs and the webhook managing its own cert.

Related issue: https://github.com/open-cluster-management/backlog/issues/1746