### PR TITLE
limit memory usage by webhook pods by being namespace focused

### DIFF
--- a/stable/cert-manager-webhook/charts/cert-manager-cainjector/templates/deployment.yaml
+++ b/stable/cert-manager-webhook/charts/cert-manager-cainjector/templates/deployment.yaml
@@ -88,10 +88,10 @@ spec:
             runAsNonRoot: {{ .Values.securityContext.container.runAsNonRoot }}
           resources:
             limits:
-              memory: "768Mi"
+              memory: "200Mi"
               cpu: "200m"
             requests:
-              memory: "150Mi"
+              memory: "100Mi"
               cpu: "100m"            
       affinity:
         podAntiAffinity:

--- a/stable/cert-manager-webhook/charts/cert-manager-cainjector/values.yaml
+++ b/stable/cert-manager-webhook/charts/cert-manager-cainjector/values.yaml
@@ -36,7 +36,8 @@ strategy: {}
 podAnnotations: {}
 
 # Optional additional arguments for cainjector
-extraArgs: []
+extraArgs:
+  - --namespace=$(POD_NAMESPACE)
 
 resources: {}
   # requests:

--- a/stable/cert-manager-webhook/values.yaml
+++ b/stable/cert-manager-webhook/values.yaml
@@ -32,10 +32,10 @@ extraArgs: []
 
 resources:
   limits:
-    memory: "768Mi"
+    memory: "200Mi"
     cpu: "200m"
   requests:
-    memory: "150Mi"
+    memory: "100Mi"
     cpu: "100m" 
 
 


### PR DESCRIPTION
Improve performance in the cert-manager-webhook pods, primarily the `cainjector` by focusing only on the ocm namespace (or specifically the namespace where cert-manager is deployed).

This will cut the memory usage by cert-manager in half (maybe a little more than half since the cainjector seems to use extra).

Issue: https://github.com/open-cluster-management/backlog/issues/7985